### PR TITLE
fix collection reference

### DIFF
--- a/includes/ModuleRegistry.php
+++ b/includes/ModuleRegistry.php
@@ -2,7 +2,7 @@
 
 namespace NewfoldLabs\WP\ModuleLoader;
 
-use WP_Forge\Collection;
+use WP_Forge\Collection\Collection;
 
 class ModuleRegistry {
 


### PR DESCRIPTION
Was using `WP_Forge\Collection` rather than `WP_Forge\COllection\Collection` so the class wasn't loading properly.

This should fix unless I'm missing something @wpscholar 