### PR TITLE
Ensure container initialization after plugins are loaded

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -112,7 +112,7 @@ function container( Container $container = null ) {
         return null;
     }
 
-	if (!$initialized) {
+	if ( !$initialized ) {
 		// If a container was passed, set it; otherwise default to an empty container.
 		$instance = ! is_null( $container ) ? $container : new Container();
 

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -101,15 +101,23 @@ function load() {
  * @return Container
  */
 function container( Container $container = null ) {
-
 	static $instance;
+	static $initialized = false;
 
-	// If no container was passed and was never set, default to an empty container
-	if ( ! isset( $instance ) ) {
+	// Ensure this runs after WordPress initialization (plugins_loaded)
+	if ( ! did_action('plugins_loaded') ) {
+        add_action('plugins_loaded', function() use ($container) {
+            container($container);
+        });
+        return null;
+    }
+
+	if (!$initialized) {
 		// If a container was passed, set it; otherwise default to an empty container.
 		$instance = ! is_null( $container ) ? $container : new Container();
 
 		do_action( 'newfold_container_set', $instance );
+		$initialized = true;
 	}
 
 	return $instance;

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -105,10 +105,10 @@ function container( Container $container = null ) {
 	static $initialized = false;
 
 	// Ensure this runs after WordPress initialization (plugins_loaded)
-	if ( ! did_action('plugins_loaded') ) {
-        add_action('plugins_loaded', function() use ($container) {
-            container($container);
-        });
+	if ( ! did_action( 'plugins_loaded' ) ) {
+		add_action( 'plugins_loaded', function() use ( $container ) {
+			container( $container );
+		});
         return null;
     }
 

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -109,7 +109,6 @@ function container( Container $container = null ) {
 		add_action( 'plugins_loaded', function() use ( $container ) {
 			container( $container );
 		});
-        return null;
     }
 
 	if ( !$initialized ) {


### PR DESCRIPTION
https://jira.newfold.com/browse/PRESS0-1821

- The container setup is now postponed until after all plugins are loaded, by waiting for the plugins_loaded hook if it hasn't happened yet.
- Added a flag called $initialized to make sure the container is set up only once, avoiding any problems from setting it up multiple times.

