### PR TITLE
Add initial docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,7 +37,7 @@ composer run test-coverage
 
 ## Keeping documentation current
 
-**When you change code, features, or workflows, update the docs so they stay accurate.**
+**When you change code, features, or workflows, update the docs so they stay accurate.** Keep **docs/index.md** current: when you add, remove, or rename doc files, update the table of contents (and quick links if present).
 
 - Keep all docs current, not only the ones listed here.
 - Prefer updating the appropriate file(s) in **docs/** over leaving docs out of date.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,44 @@
+# Agent guidance – wp-module-loader
+
+This file gives AI agents a quick orientation to the repo. For full detail, see the **docs/** directory.
+
+## What this project is
+
+- **wp-module-loader** – Registers and manages Newfold modules used within WordPress brand plugins (e.g. Bluehost, HostGator). Host plugins set a shared container and call `setContainer()`; then Composer-loaded modules register with `NewfoldLabs\WP\ModuleLoader\register()`. This package provides the registry, container extension, and the `load()` flow that runs active modules. Maintained by Newfold Labs.
+
+- **Stack:** PHP 7.3+ (see `composer.json` platform). No frontend; consumed as a Composer dependency by brand plugins.
+
+- **Architecture:** Host plugin gets a `NewfoldLabs\Container\Container` (or equivalent), sets it via `NewfoldLabs\WP\ModuleLoader\container($container)`. Modules register with `register([ 'name' => '...', 'label' => '...', 'callback' => ..., 'isActive' => ... ])`. On `after_setup_theme` (priority 100), `load()` runs each active module’s callback with `(container(), module)`.
+
+## Key paths
+
+| Purpose | Location |
+|---------|----------|
+| Bootstrap | `bootstrap.php` – hooks `load` on `after_setup_theme` |
+| Container / Plugin | `includes/Container.php`, `includes/Plugin.php` |
+| Module registry & API | `includes/ModuleRegistry.php`, `includes/Module.php` |
+| Public API (register, load, container, options) | `includes/functions.php` |
+| Tests | `tests/` (Codeception wpunit) |
+
+## Essential commands
+
+```bash
+composer install
+composer run test        # codecept run wpunit
+composer run test-coverage
+```
+
+## Documentation
+
+- **Full documentation** for both agents and humans is in **docs/**. Start with **docs/index.md** for a table of contents.
+- **CLAUDE.md** in this repo is a symlink to this file (AGENTS.md).
+
+---
+
+## Keeping documentation current
+
+**When you change code, features, or workflows, update the docs so they stay accurate.**
+
+- Keep all docs current, not only the ones listed here.
+- Prefer updating the appropriate file(s) in **docs/** over leaving docs out of date.
+- When adding or changing REST routes or public API, update **api.md** (endpoints table). When adding or changing dependencies, update **dependencies.md**. When cutting a release, update **docs/changelog.md**.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/docs/dependencies.md
+++ b/docs/dependencies.md
@@ -1,3 +1,10 @@
+---
+name: wp-module-loader
+title: Dependencies
+description: Composer and npm dependencies.
+updated: 2025-03-18
+---
+
 # Dependencies
 
 This document lists the main Composer dependencies of wp-module-loader and how they are used. Routine WordPress core or dev tooling is omitted.

--- a/docs/dependencies.md
+++ b/docs/dependencies.md
@@ -1,0 +1,20 @@
+# Dependencies
+
+This document lists the main Composer dependencies of wp-module-loader and how they are used. Routine WordPress core or dev tooling is omitted.
+
+## Runtime
+
+| Package | Purpose |
+|---------|---------|
+| **newfold-labs/container** | PSR-11-compatible DI container. This package extends it as `NewfoldLabs\WP\ModuleLoader\Container` and adds `plugin()`. The host plugin sets the container instance; modules receive it in their callback. |
+| **wp-forge/collection** | `ModuleRegistry::collection()` uses `Collection::make()` to store registered modules. Used for `put`, `forget`, `get`, `has`, `where`, `pluck`. |
+| **wp-forge/fluent** | `Module` and `Plugin` extend `Fluent` for attribute-style access (e.g. `$module->name`, `$module->callback`). |
+| **wp-forge/wp-options** | `Options` (option name `newfold_active_modules`) persists which modules are active. Used in `ModuleRegistry` and in `load()` to save state. |
+
+## Dev
+
+- **johnpbloch/wordpress** – WordPress core for WPUnit tests.
+- **lucatume/wp-browser** – Codeception and WPUnit integration.
+- **phpunit/phpcov** – Coverage merging and HTML report.
+
+All runtime deps are required by host plugins that depend on wp-module-loader; they are part of the loader’s public contract (container, options key, and collection behavior).

--- a/docs/development.md
+++ b/docs/development.md
@@ -1,0 +1,22 @@
+# Development
+
+## Testing
+
+- **WPUnit (Codeception):** `composer run test` runs the `wpunit` suite.
+- **Coverage:** `composer run test-coverage` generates a merged coverage report; open `tests/_output/html/index.html` to view.
+
+Test bootstrap and helpers live under `tests/` (e.g. `tests/_support/`, `tests/wpunit/`).
+
+## Code style
+
+There is no custom lint script in this repo. Follow WordPress PHP coding standards when contributing. Host plugins that depend on this package may run their own PHPCS config over vendor source if needed.
+
+## Day-to-day workflow
+
+1. Make changes in `includes/` or `bootstrap.php`.
+2. Run `composer run test` before committing.
+3. When adding or changing the public API (e.g. new helper in `functions.php`), update [integration.md](integration.md) and [overview.md](overview.md) as needed.
+
+## Version and release
+
+This package is versioned and released to the Newfold Satis repository. Version is defined in `composer.json`. When cutting a release, update **docs/changelog.md** with the changes for that version.

--- a/docs/development.md
+++ b/docs/development.md
@@ -1,3 +1,10 @@
+---
+name: wp-module-loader
+title: Development
+description: Lint, test, and workflow.
+updated: 2025-03-18
+---
+
 # Development
 
 ## Testing

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,0 +1,41 @@
+# Getting started
+
+## Prerequisites
+
+- **PHP** 7.3+ (see `composer.json` platform).
+- **Composer** for dependencies.
+- **Git** for the repository.
+
+## Install
+
+From the package root:
+
+```bash
+composer install
+```
+
+This pulls in `newfold-labs/container`, `wp-forge/collection`, `wp-forge/fluent`, and `wp-forge/wp-options`.
+
+## Run tests
+
+```bash
+composer run test
+```
+
+Uses Codeception with the `wpunit` suite. For coverage:
+
+```bash
+composer run test-coverage
+```
+
+Then open `tests/_output/html/index.html` to view the report.
+
+## Using the loader in a host plugin
+
+This package is consumed as a Composer dependency. In the host plugin you typically:
+
+1. Create a container and set it with `NewfoldLabs\WP\ModuleLoader\container($container)`.
+2. Require or autoload other `newfold-labs/wp-module-*` packages; each calls `register()` with its name, label, callback, and default state.
+3. On `after_setup_theme`, the loader’s `load()` runs (hooked in `bootstrap.php`), which invokes each active module’s callback with `(container(), module)`.
+
+See [integration.md](integration.md) for details.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,3 +1,10 @@
+---
+name: wp-module-loader
+title: Getting started
+description: Prerequisites, install, and run.
+updated: 2025-03-18
+---
+
 # Getting started
 
 ## Prerequisites

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,21 @@
+# wp-module-loader – Documentation index
+
+This directory holds documentation for wp-module-loader, for both **humans** and **AI agents**. Start here to find the right doc for your task.
+
+## Table of contents
+
+| Document | Description |
+|----------|-------------|
+| [overview.md](overview.md) | What the module does, who maintains it, and high-level behavior. |
+| [getting-started.md](getting-started.md) | Prerequisites, clone/install, and how to run tests. |
+| [integration.md](integration.md) | How host plugins use the loader (container, register, load) and how modules register. |
+| [development.md](development.md) | Lint, test, and day-to-day workflow. |
+| [dependencies.md](dependencies.md) | Composer dependencies and how they are used. |
+
+## Quick links
+
+- **New to the repo:** Read [overview.md](overview.md) then [getting-started.md](getting-started.md).
+- **Integrating in a host plugin:** See [integration.md](integration.md).
+- **Changing behavior or adding modules:** See [integration.md](integration.md) and [dependencies.md](dependencies.md).
+
+The root **AGENTS.md** file gives a short agent-oriented summary and points here for full docs.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,3 +1,10 @@
+---
+name: wp-module-loader
+title: Documentation index
+description: Table of contents and quick links.
+updated: 2025-03-18
+---
+
 # wp-module-loader – Documentation index
 
 This directory holds documentation for wp-module-loader, for both **humans** and **AI agents**. Start here to find the right doc for your task.

--- a/docs/index.md
+++ b/docs/index.md
@@ -11,6 +11,7 @@ This directory holds documentation for wp-module-loader, for both **humans** and
 | [integration.md](integration.md) | How host plugins use the loader (container, register, load) and how modules register. |
 | [development.md](development.md) | Lint, test, and day-to-day workflow. |
 | [dependencies.md](dependencies.md) | Composer dependencies and how they are used. |
+| [release.md](release.md) | Release process: use the Newfold Prepare Release workflow. |
 
 ## Quick links
 

--- a/docs/integration.md
+++ b/docs/integration.md
@@ -1,0 +1,40 @@
+# Integration
+
+## How the loader fits in
+
+Host plugins (e.g. Bluehost WordPress Plugin) use wp-module-loader to:
+
+1. **Set the container** – The host creates a `NewfoldLabs\Container\Container` (or compatible), registers the plugin instance and any shared config (e.g. brand, cache types), then calls `NewfoldLabs\WP\ModuleLoader\container($container)` so the loader (and modules) use that single instance.
+2. **Load modules** – Other Newfold packages (e.g. `wp-module-performance`, `wp-module-coming-soon`) are Composer dependencies. When they are loaded, they call `NewfoldLabs\WP\ModuleLoader\register([ ... ])` with a name, label, callback, and default active state.
+3. **Run callbacks** – On `after_setup_theme` (priority 100), the loader’s `load()` runs. It iterates over active modules and calls each callback with `(container(), module)`.
+
+So the host never calls `load()` directly; it is hooked in `bootstrap.php`. The host only sets the container before other modules are loaded.
+
+## Container and options
+
+- **Container:** Extended in this package as `NewfoldLabs\WP\ModuleLoader\Container` (adds `plugin()`). The host usually sets `plugin` and other keys before passing the container to the loader.
+- **Options:** Active state is stored via `WP_Forge\Options\Options` under the option name `newfold_active_modules`. Keys are module names; values are booleans. The loader reads/writes this in `ModuleRegistry` and at the end of `load()`.
+
+## Registering a module
+
+From another package (e.g. wp-module-performance), typically in its bootstrap or main file:
+
+```php
+use function NewfoldLabs\WP\ModuleLoader\register;
+
+register([
+    'name'     => 'performance',
+    'label'    => 'Performance',
+    'callback' => function ( $container, $module ) {
+        // Bootstrap the module using $container and $module.
+    },
+    'isActive' => true,
+    'isHidden' => false,
+]);
+```
+
+Required: `name`, `label`, `callback`. Optional: `isActive` (default `false`), `isHidden` (default `false`). The callback receives the shared container and the module instance.
+
+## Hooks
+
+- **`newfold_container_set`** – Fired when the container is set (in `container()`). Passes the container instance. Host plugins can use this to configure the container before modules run.

--- a/docs/integration.md
+++ b/docs/integration.md
@@ -1,3 +1,10 @@
+---
+name: wp-module-loader
+title: Integration
+description: How the module registers and integrates.
+updated: 2025-03-18
+---
+
 # Integration
 
 ## How the loader fits in

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -1,0 +1,22 @@
+# Overview
+
+## What the module does
+
+**wp-module-loader** is the core component that handles registration and management of Newfold modules inside WordPress brand plugins. It does not ship a UI; it provides:
+
+- A **container** (extending `NewfoldLabs\Container\Container`) that host plugins set and pass to modules.
+- A **module registry**: modules register with `name`, `label`, `callback`, and default `isActive`/`isHidden`.
+- **Persistence** of active state via `WP_Forge\Options\Options` (option key `newfold_active_modules`).
+- A **load** step on `after_setup_theme`: runs each active module’s callback with `(container(), module)`.
+
+Brand plugins (e.g. Bluehost, HostGator) depend on this package via Composer, set the container, then require other `newfold-labs/wp-module-*` packages that call `register()` during their bootstrap.
+
+## Who maintains it
+
+- **Newfold Labs** (Newfold Digital) maintains the package. It is distributed via the Newfold Satis repository and used by all Newfold WordPress brand plugins.
+
+## High-level features
+
+- **Container:** Host sets the DI container via `container($container)`; modules receive it in their callback.
+- **Module API:** `register()`, `unregister()`, `activate()`, `deactivate()`, `isActive()`, `load()`.
+- **Options:** Active state is stored in a single WordPress option so it survives requests.

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -1,3 +1,10 @@
+---
+name: wp-module-loader
+title: Overview
+description: What the module does and who maintains it.
+updated: 2025-03-18
+---
+
 # Overview
 
 ## What the module does

--- a/docs/release.md
+++ b/docs/release.md
@@ -1,0 +1,26 @@
+# Release process
+
+This module follows the standard Newfold release process using a reusable workflow.
+
+## Prepare release (recommended)
+
+1. **Run the Newfold Prepare Release workflow**
+   - In GitHub: **Actions** → **Newfold Prepare Release** → **Run workflow**.
+   - Choose the version **level**: `patch`, `minor`, or `major`.
+   - The workflow will:
+     - Bump the version to the chosen level (in the appropriate files, e.g. `composer.json`, plugin header, or `package.json`).
+     - Run a fresh build if the module has frontend assets.
+     - Update language files (i18n).
+     - Open a pull request with the changes.
+
+2. **Review and merge** the prep-release PR.
+
+3. **Tag and publish** the release (e.g. create a GitHub release from the tag, or follow your team’s process for Satis/packagist).
+
+## Manual release (fallback)
+
+If the workflow is unavailable, bump the version manually in the same places the workflow would (see `.github/workflows/newfold-prep-release.yml` inputs for `json-file` and `php-file`), run any build and i18n commands, then tag and release. Prefer using the workflow when possible for consistency.
+
+## After each release
+
+- Update **docs/changelog.md** with the changes in the release.

--- a/docs/release.md
+++ b/docs/release.md
@@ -1,6 +1,21 @@
+---
+name: wp-module-loader
+title: Release process
+description: Release process and version bump.
+updated: 2025-03-18
+---
+
 # Release process
 
 This module follows the standard Newfold release process using a reusable workflow.
+
+## Build step required
+
+See `.github/workflows/newfold-prep-release.yml`: the workflow uses `json-file` and `php-file` inputs. If this module has a frontend (e.g. `package.json` has a `build` script), run `npm run build` before tagging; the workflow runs it automatically. Otherwise no build step is required.
+
+## Hardcoded versions to bump
+
+The workflow bumps the version in the files specified in `.github/workflows/newfold-prep-release.yml` (`json-file` and `php-file`—typically **bootstrap.php** for the PHP version constant (e.g. `NFD_*_MODULE_VERSION`) and **package.json** for the `version` field). If releasing manually, update those files, run any build and i18n commands, then tag and release.
 
 ## Prepare release (recommended)
 


### PR DESCRIPTION
Adds AGENTS.md, CLAUDE.md (symlink to AGENTS.md), and docs/ per the Newfold modules documentation rollout: overview, getting-started, integration, development, dependencies.

Made with [Cursor](https://cursor.com)