### PR TITLE
Minimally scope permissions in GitHub Actions workflows

### DIFF
--- a/.github/workflows/brand-plugin-test.yml
+++ b/.github/workflows/brand-plugin-test.yml
@@ -19,6 +19,7 @@ jobs:
     name: Setup
     runs-on: ubuntu-latest
     permissions: {} # No checkout or GitHub API use; extracts branch metadata for reusable workflow inputs only
+    timeout-minutes: 10
     outputs:
       branch: ${{ steps.extract_branch.outputs.branch }}
     steps:
@@ -34,6 +35,7 @@ jobs:
     uses: newfold-labs/workflows/.github/workflows/module-plugin-test.yml@main
     permissions:
       contents: read # Matches downstream reusable workflow; required for checkout/composer/GitHub-hosted actions using GITHUB_TOKEN on private repos
+    timeout-minutes: 45
     with:
       module-repo: ${{ github.repository }}
       module-branch: ${{ needs.setup.outputs.branch }}
@@ -46,6 +48,7 @@ jobs:
     uses: newfold-labs/workflows/.github/workflows/module-plugin-test.yml@main
     permissions:
       contents: read # Matches downstream reusable workflow; required for checkout/composer/GitHub-hosted actions using GITHUB_TOKEN on private repos
+    timeout-minutes: 45
     with:
       module-repo: ${{ github.repository }}
       module-branch: ${{ needs.setup.outputs.branch }}
@@ -58,6 +61,7 @@ jobs:
     uses: newfold-labs/workflows/.github/workflows/module-plugin-test.yml@main
     permissions:
       contents: read # Matches downstream reusable workflow; required for checkout/composer/GitHub-hosted actions using GITHUB_TOKEN on private repos
+    timeout-minutes: 45
     with:
       module-repo: ${{ github.repository }}
       module-branch: ${{ needs.setup.outputs.branch }}
@@ -70,6 +74,7 @@ jobs:
     uses: newfold-labs/workflows/.github/workflows/module-plugin-test.yml@main
     permissions:
       contents: read # Matches downstream reusable workflow; required for checkout/composer/GitHub-hosted actions using GITHUB_TOKEN on private repos
+    timeout-minutes: 45
     with:
       module-repo: ${{ github.repository }}
       module-branch: ${{ needs.setup.outputs.branch }}
@@ -82,6 +87,7 @@ jobs:
     uses: newfold-labs/workflows/.github/workflows/module-plugin-test.yml@main
     permissions:
       contents: read # Matches downstream reusable workflow; required for checkout/composer/GitHub-hosted actions using GITHUB_TOKEN on private repos
+    timeout-minutes: 45
     with:
       module-repo: ${{ github.repository }}
       module-branch: ${{ needs.setup.outputs.branch }}

--- a/.github/workflows/brand-plugin-test.yml
+++ b/.github/workflows/brand-plugin-test.yml
@@ -10,10 +10,15 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.sha }}
   cancel-in-progress: true
 
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
+permissions: {}
+
 jobs:
   setup:
     name: Setup
     runs-on: ubuntu-latest
+    permissions: {} # No checkout or GitHub API use; extracts branch metadata for reusable workflow inputs only
     outputs:
       branch: ${{ steps.extract_branch.outputs.branch }}
     steps:
@@ -27,6 +32,8 @@ jobs:
     name: Bluehost Build and Test
     needs: setup
     uses: newfold-labs/workflows/.github/workflows/module-plugin-test.yml@main
+    permissions:
+      contents: read # Matches downstream reusable workflow; required for checkout/composer/GitHub-hosted actions using GITHUB_TOKEN on private repos
     with:
       module-repo: ${{ github.repository }}
       module-branch: ${{ needs.setup.outputs.branch }}
@@ -37,6 +44,8 @@ jobs:
     name: HostGator Build and Test
     needs: setup
     uses: newfold-labs/workflows/.github/workflows/module-plugin-test.yml@main
+    permissions:
+      contents: read # Matches downstream reusable workflow; required for checkout/composer/GitHub-hosted actions using GITHUB_TOKEN on private repos
     with:
       module-repo: ${{ github.repository }}
       module-branch: ${{ needs.setup.outputs.branch }}
@@ -47,6 +56,8 @@ jobs:
     name: Web.com Build and Test
     needs: setup
     uses: newfold-labs/workflows/.github/workflows/module-plugin-test.yml@main
+    permissions:
+      contents: read # Matches downstream reusable workflow; required for checkout/composer/GitHub-hosted actions using GITHUB_TOKEN on private repos
     with:
       module-repo: ${{ github.repository }}
       module-branch: ${{ needs.setup.outputs.branch }}
@@ -57,6 +68,8 @@ jobs:
     name: Crazy Domains Build and Test
     needs: setup
     uses: newfold-labs/workflows/.github/workflows/module-plugin-test.yml@main
+    permissions:
+      contents: read # Matches downstream reusable workflow; required for checkout/composer/GitHub-hosted actions using GITHUB_TOKEN on private repos
     with:
       module-repo: ${{ github.repository }}
       module-branch: ${{ needs.setup.outputs.branch }}
@@ -67,6 +80,8 @@ jobs:
     name: Mojo Build and Test
     needs: setup
     uses: newfold-labs/workflows/.github/workflows/module-plugin-test.yml@main
+    permissions:
+      contents: read # Matches downstream reusable workflow; required for checkout/composer/GitHub-hosted actions using GITHUB_TOKEN on private repos
     with:
       module-repo: ${{ github.repository }}
       module-branch: ${{ needs.setup.outputs.branch }}

--- a/.github/workflows/codecoverage-main.yml
+++ b/.github/workflows/codecoverage-main.yml
@@ -13,10 +13,17 @@ on:
       - master
   workflow_dispatch:
 
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
+permissions: {}
+
 jobs:
 
   codecoverage:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write      # Required to clone and push to gh-pages via git-auto-commit-action with GITHUB_TOKEN
+      pull-requests: write # Required to post coverage comments via mshick/add-pr-comment on pull requests
 
     services:
       mysql:

--- a/.github/workflows/codecoverage-main.yml
+++ b/.github/workflows/codecoverage-main.yml
@@ -24,7 +24,7 @@ jobs:
     permissions:
       contents: write      # Required to clone and push to gh-pages via git-auto-commit-action with GITHUB_TOKEN
       pull-requests: write # Required to post coverage comments via mshick/add-pr-comment on pull requests
-
+    timeout-minutes: 60
     services:
       mysql:
         image: mysql:5.7 # Password auth did not work on 8.0 on PHP 7.3, it did seem to work for PHP 7.4+

--- a/.github/workflows/satis-webhook.yml
+++ b/.github/workflows/satis-webhook.yml
@@ -14,6 +14,7 @@ jobs:
     name: Send Webhook
     runs-on: ubuntu-latest
     permissions: {} # Steps only use ${{ secrets.WEBHOOK_TOKEN }} for repository_dispatch; no GITHUB_TOKEN usage
+    timeout-minutes: 30
     steps:
 
       - name: Set Package

--- a/.github/workflows/satis-webhook.yml
+++ b/.github/workflows/satis-webhook.yml
@@ -5,10 +5,15 @@ on:
     types:
       - created
 
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
+permissions: {}
+
 jobs:
   webhook:
     name: Send Webhook
     runs-on: ubuntu-latest
+    permissions: {} # Steps only use ${{ secrets.WEBHOOK_TOKEN }} for repository_dispatch; no GITHUB_TOKEN usage
     steps:
 
       - name: Set Package


### PR DESCRIPTION
This updates the GitHub Actions workflow files to:

- Grant minimally-scoped permissions to each job to adhere to the principle of least privilege
- Specify a timeout on each job to prevent runaway processes consuming too many minutes (the default is 360)

Once this PR is merged, [the Settings -> Actions -> Workflow permissions setting](https://github.com/WordPress/wordpress-playground/settings/actions) can be changed by a repo admin to "Read repository contents and packages permissions".

For more information, see [PRESS11-470](https://newfold.atlassian.net/browse/PRESS11-470).

## References

- https://docs.github.com/en/actions/reference/security/secure-use
- https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#jobsjob_idtimeout-minutes

## Use of AI

Cursor was used with (Claude Opus 4.7 and Composer 2.0 at varying points) to analyze the repository and make the initial changes.

When this PR is marked "ready for review" it means that I have manually reviewed all permissions and timeouts that were changed and made any necessary adjustments.

As a part of the analysis, the following summary was created:

## Status

| Field | Value |
|---|---|
| Workflows scanned | 3 (`brand-plugin-test.yml`, `codecoverage-main.yml`, `satis-webhook.yml`) |
| Branch | `add/scoped-workflow-permissions` (created) |
| Permissions commit | b8d83a0 |
| Timeouts commit | 0b1323d |


## Top-level `permissions: {}`

| Category | Entry |
|---|---|
| Workflows that were missing the top-level `permissions: {}` directive (added in this run): | `brand-plugin-test.yml` |
| Workflows that were missing the top-level `permissions: {}` directive (added in this run): | `codecoverage-main.yml` |
| Workflows that were missing the top-level `permissions: {}` directive (added in this run): | `satis-webhook.yml` |


## Job-level `permissions:` additions

| Workflow file | Summary | Job | Permissions / notes |
|---|---|---|---|
| satis-webhook.yml | 1 job was missing a scoped `permissions:` directive | webhook | `{}` [3] |
| codecoverage-main.yml | 1 job was missing a scoped `permissions:` directive | codecoverage | `contents: write`, `pull-requests: write` [3] |
| brand-plugin-test.yml | 6 jobs were missing a scoped `permissions:` directive | setup | `{}` [3] |
| brand-plugin-test.yml | 6 jobs were missing a scoped `permissions:` directive | Bluehost Build and Test | `contents: read` [2] |
| brand-plugin-test.yml | 6 jobs were missing a scoped `permissions:` directive | HostGator Build and Test | `contents: read` [2] |
| brand-plugin-test.yml | 6 jobs were missing a scoped `permissions:` directive | Web.com Build and Test | `contents: read` [2] |
| brand-plugin-test.yml | 6 jobs were missing a scoped `permissions:` directive | Crazy Domains Build and Test | `contents: read` [2] |
| brand-plugin-test.yml | 6 jobs were missing a scoped `permissions:` directive | Mojo Build and Test | `contents: read` [2] |


## Permissions corrections (previously incorrect)

No pre-existing configured `permissions:` were identified as incorrect.

## `timeout-minutes` additions

| Workflow | Job | Minutes / action | Rationale |
|---|---|---|---|
| satis-webhook.yml | webhook | `30` | Webhook packaging and dispatch are quick; thirty minutes guards against stalled runners without constraining legitimate runs. |
| codecoverage-main.yml | codecoverage | `60` | MySQL setup, Composer, PHP/Codeception matrices, and merging coverage routinely need more wall time than a short smoke workflow. |
| brand-plugin-test.yml | setup | `10` | The job only echoes branch outputs; ten minutes avoids runaway executions while exceeding normal runtime by a wide margin. |
| brand-plugin-test.yml | Bluehost Build and Test | `45` | The reusable workflow runs Composer/npm, builds, `wp-env`, and Cypress suites, which can be slow on cold caches. |
| brand-plugin-test.yml | HostGator Build and Test | `45` | Same rationale as Bluehost (`module-plugin-test` reusable workflow workload). |
| brand-plugin-test.yml | Web.com Build and Test | `45` | Same rationale as Bluehost (`module-plugin-test` reusable workflow workload). |
| brand-plugin-test.yml | Crazy Domains Build and Test | `45` | Same rationale as Bluehost (`module-plugin-test` reusable workflow workload). |
| brand-plugin-test.yml | Mojo Build and Test | `45` | Same rationale as Bluehost (`module-plugin-test` reusable workflow workload). |


## Notes / blockers

| # | Note |
|---:|---|
| 1 | Reusable `newfold-labs/workflows/.github/workflows/module-plugin-test.yml@main` already scopes its inner job to `contents: read`; caller jobs mirror that ceiling so the granting token cannot elevate beyond what the reusable workflow declares. Confirm in live runs whether `contents: read` continues to suffice for artifacts/caching behaviour under your organization’s Actions defaults (`actions/cache`/`upload-artifact`); if workflows fail post-hardening, update `module-plugin-test.yml` upstream to declare any additional minimal scopes rather than widening callers alone. |


