### PR TITLE
Add AI code review workflow with Dependabot skip

### DIFF
--- a/.github/workflows/ai-code-review.yml
+++ b/.github/workflows/ai-code-review.yml
@@ -1,0 +1,41 @@
+##
+# AI pull request review via Cloudflare AI Gateway (central reusable workflow).
+# Posts a sticky PR comment and optional Actions check annotations (file/line) from the model JSON.
+#
+# Secrets (repository or organization): CLOUDFLARE_ACCOUNT_ID, CLOUDFLARE_AI_GATEWAY_TOKEN
+# Variable (organization or repository): CLOUDFLARE_AI_GATEWAY_ID — gateway id path segment (not a secret).
+#
+# Pin `uses: ...@main` (or a commit SHA). Set `prompts_ref` to the same ref (e.g. main).
+##
+name: AI Code Review
+
+on:
+  pull_request:
+    types: [ opened, synchronize, reopened, ready_for_review ]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.sha }}
+  cancel-in-progress: true
+
+permissions: {}
+
+jobs:
+  review:
+    # Skip Dependabot PRs: GitHub withholds repo secrets from Dependabot-context
+    # runs, so the AI gateway secrets are empty and the review would hard-fail.
+    # A skipped job counts as passing, so it never blocks Dependabot auto-merge.
+    if: >-
+      github.event.pull_request.draft == false &&
+      github.event.pull_request.head.repo.fork == false &&
+      github.actor != 'dependabot[bot]'
+    name: Review PR diff
+    uses: newfold-labs/workflows/.github/workflows/reusable-code-review.yml@main
+    with:
+      prompts_ref: main
+    permissions:
+      contents: read
+      pull-requests: write
+      checks: write
+    secrets:
+      CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+      CLOUDFLARE_AI_GATEWAY_TOKEN: ${{ secrets.CLOUDFLARE_AI_GATEWAY_TOKEN }}


### PR DESCRIPTION
## Summary
- Add the shared AI code review workflow
- Skip the workflow on Dependabot PRs, since GitHub withholds org secrets from Dependabot-context runs

## Test plan
- [ ] Verify workflow YAML is valid
- [ ] Confirm AI code review runs on normal PRs
- [ ] Confirm Dependabot PRs skip the review job (job shows as skipped, not failed)